### PR TITLE
Fix for beep bug if lights are changed too quickly

### DIFF
--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -629,7 +629,7 @@ void Buzzer_Task(void)
 				{	
 					ring_frequency++;
 					buzzer_step = 0;
-					if(ring_frequency == Gear_Position)
+					if(ring_frequency >= Gear_Position)
 					{
 						ring_frequency = 0;
 						gear_position_last = Gear_Position;


### PR DESCRIPTION
This stops the forever beeping if you change the lights before the buzzer has stopped from the previous change