### PR TITLE
Remove redundant code added by last commit and fix command interval

### DIFF
--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -16,6 +16,7 @@ static void lcmConfigReset(void)
 	// Persist across power cycles
 	// lcmConfig.bootAnimation = DEFAULT;
 	// lcmConfig.dutyBeep = 90;
+	// lcmConfig.debug = false;
 }
 
 // brightnesses for Gear 1, 2, 3:
@@ -872,7 +873,7 @@ void Usart_Task(void)
 				if (commandIndex % 20 == 0) {
 					// Sending lighting every 20th frame
 					command = COMM_CHARGE_INFO;
-				} else if (DEBUG_ENABLED && commandIndex % 2 == 0) {
+				} else if (lcmConfig.debug && commandIndex % 2 == 0) {
 					// Send debug info every 2nd frame if enabled
 					command = COMM_CUSTOM_DEBUG;
 				}

--- a/LCM/Code/App/task.h
+++ b/LCM/Code/App/task.h
@@ -23,7 +23,6 @@ typedef enum
 #define   DUTY_CYCLE          		0.9
 #define   VOLTAGE_RECEIPT     		0.02
 #define	  CHARGE_COMMAND_TIME		1000 		// frequency of notifying the float package of current charge state
-#define   DEBUG_ENABLED				false		// enable debug messages	
 /*******************************************************************************/
 #define   VESC_RPM_WIDTH      		-200
 #define   WS2812_1_BRIGHTNESS 		100

--- a/LCM/Code/App/vesc_uasrt.c
+++ b/LCM/Code/App/vesc_uasrt.c
@@ -312,9 +312,9 @@ uint8_t Protocol_Parse(uint8_t * message)
 		  if (len < 12) {
 				break;
 			}
-		  uint8_t magicnr = pdata[ind++];
-		  uint8_t floatcmd = pdata[ind++];
-		  if ((magicnr != 101) || (floatcmd != FLOAT_COMMAND_LCM_POLL)) {
+		  	uint8_t magicnr = pdata[ind++];
+		  	uint8_t floatcmd = pdata[ind++];
+			if ((magicnr != 101) || (floatcmd != FLOAT_COMMAND_LCM_POLL)) {
 				break;
 			}
 			data.floatPackageSupported = true;

--- a/LCM/Code/App/vesc_uasrt.c
+++ b/LCM/Code/App/vesc_uasrt.c
@@ -26,6 +26,7 @@ typedef enum {
 	// Sys commands
 	POWER_OFF = 100,
 	CHARGE_CUTOFF = 101,
+	DEBUG = 255,
 } ControlCommands;
 
 /**************************************************
@@ -130,7 +131,7 @@ void Get_Vesc_Pack_Data(COMM_PACKET_ID id)
 	if (id == COMM_CUSTOM_DEBUG) {
 		command[0] = COMM_CUSTOM_APP_DATA;
 		command[1] = 101;
-		command[2] = 99; // FLOAT_COMMAND_LCM_DEBUG - this doesn't exist
+		command[2] = 99; // FLOAT_COMMAND_LCM_DEBUG
 		command[3] = Power_Flag;
 		command[4] = Charge_Flag;
 		command[5] = Buzzer_Flag;
@@ -241,6 +242,9 @@ void Process_Command(uint8_t command, uint8_t data)
 			return;
 		case CHARGE_CUTOFF:
 			lcmConfig.chargeCutoffVoltage = data;
+			return;
+		case DEBUG:
+			lcmConfig.debug = data == 1;
 			return;
 		}
 }

--- a/LCM/Code/App/vesc_uasrt.h
+++ b/LCM/Code/App/vesc_uasrt.h
@@ -36,6 +36,7 @@ typedef struct {
 	bool boardOff;
 	BootAnimation bootAnimation;
 	bool isSet;
+	bool debug;
 }lcmConfig_t;
 
 extern uint8_t VESC_RX_Buff[256];


### PR DESCRIPTION
Migrate to relative frequencies for uart commands
Remove unneeded check for cutoff voltage

All tested and working well when issuing charge cutoff commands from VESC Tool