### PR TITLE
Fix out-of-bounds bootAnimation check

### DIFF
--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -229,7 +229,7 @@ void WS2812_Boot(void)
 		{{30,0,0}, {30,30,30}, {0,0,30}, {30,0,0}, {30,30,30}, {0,0,30}, {30,0,0}, {30,30,30}, {0,0,30}, {30,0,0}}
 };
 
-	if (lcmConfig.bootAnimation >= sizeof(bootAnims)) {
+	if (lcmConfig.bootAnimation < 0 || lcmConfig.bootAnimation >= BOOT_ANIMATION_COUNT) {
 		// Invalid boot animation
 		lcmConfig.bootAnimation = 0;
 	}


### PR DESCRIPTION
Compare against BOOT_ANIMATION_COUNT instead of using byte size of array (which I think it would resolve to 90)