### PR TITLE
Updates for PintV and XRV

### DIFF
--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -82,7 +82,8 @@ void KEY1_Task(void)
 		break;
 
 		case 3:         // Long press
-			if (Power_Flag < 3) {
+			if(Power_Flag == 2) // Boot completed
+			{
 				Power_Flag = 4;  // VESC power off
 				Power_Time = 0;
 			}

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -549,21 +549,14 @@ void Power_Task(void)
 
 void CheckPowerLevel(float battery_voltage)
 {
-	float battVoltages[10] = {4.054, 4.01, 3.908, 3.827, 3.74, 3.651, 3.571, 3.485, 3.38, 3.0}; //P42A
-	//float battVoltages[10] = {4.07, 4.025, 3.91, 3.834, 3.746, 3.607, 3.49, 3.351, 3.168, 2.81}; //DG40
-	//float battVoltages[10] = { 4.1, 4.00, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.1 }; // Sony VTC6
-	//float battcellcurve[10] = {4.054, 4.01, 3.908, 3.827, 3.74, 3.651, 3.571, 3.485, 3.38, 3.0};   //P42A
-								   //{4.07, 4.025, 3.91, 3.834, 3.746, 3.607, 3.49, 3.351, 3.168, 2.81}}; //DG40
-	//static uint8_t cell_type_last = 1; //CELL_TYPE P42A equates out to 0
+	const float battcellcurves[][10] = {
+		{4.054, 4.01, 3.908, 3.827, 3.74, 3.651, 3.571, 3.485, 3.38, 3.0},  // P42A
+		{4.07, 4.025, 3.91, 3.834, 3.746, 3.607, 3.49, 3.351, 3.168, 2.81}, // DG40
+		{4.1, 4.00, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.1}                 // Sony VTC6
+	};
 
-	/*if (CELL_TYPE != cell_type_last) // If !P42a run once at boot or on change
-	{
-		cell_type_last = CELL_TYPE;
-		for (int i=0;i<10;i++)
-		{
-			battVoltages[i] = battcellcurves[cell_type_last][i];
-		}
-	}*/
+	static uint8_t cell_type = DEFAULT_CELL_TYPE;
+	volatile const float* battVoltages = battcellcurves[cell_type];
 
 	// Default: Between zero and min voltage
 	Power_Display_Flag = 10;

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -542,6 +542,8 @@ void Power_Task(void)
 
 		case 4:// New Power state for shutdown sequence
 			WS2812_Display_Flag = 3;
+		break;
+		
 		default:
 		break;
 	}
@@ -816,14 +818,23 @@ void Buzzer_Task(void)
 	static uint8_t ring_frequency = 0;
 	static uint16_t sound_frequency = 0;
 
-	if(Power_Flag != 2 || Buzzer_Flag == 1)
+	if(Power_Flag < 2 || Buzzer_Flag == 1)
 	{
 		BUZZER_OFF;
 		buzzer_step = 0;
 		return;
 	}
-	
-	if(Buzzer_Frequency == 0 && gear_position_last == Gear_Position)
+	else if (Power_Flag == 4)
+	{
+		// Beep when powering off
+		if (buzzer_step == 0)
+		{
+			Buzzer_Ring(200);
+			buzzer_step = 2;
+		}
+		return;
+	}
+	else if(Buzzer_Frequency == 0 && gear_position_last == Gear_Position)
 	{
 		BUZZER_OFF;
 		buzzer_step = 0;

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -381,7 +381,7 @@ static void WS2812_Idle()
 				Idle_Time = 0;
 			}
 		}
-		else {
+		else if (Idle_Time > 10000) {
 			WS2818_Knight_Rider(WS2812_Measure);
 		}
 		return;

--- a/LCM/Code/App/task.h
+++ b/LCM/Code/App/task.h
@@ -11,8 +11,8 @@ typedef enum
 {
 	P42A,
 	DG40,
-    VTC6
-} CELL_TYPES;
+	VTC6
+} CELL_TYPE;
 
 //#define PINTV
 #define XRV
@@ -22,34 +22,34 @@ typedef enum
 #define USE_BUZZER
 
 #if defined(GTV)
-#define   BATTERY_STRING      		18
-#define   DEFAULT_CELL_TYPE         P42A
+#define   BATTERY_STRING			18
+#define   DEFAULT_CELL_TYPE			P42A
 #elif defined(PINTV) || defined(XRV)
-#define   BATTERY_STRING      		15
-#define   DEFAULT_CELL_TYPE         VTC6
+#define   BATTERY_STRING			15
+#define   DEFAULT_CELL_TYPE			VTC6
 #elif defined(ADV)
-#define   BATTERY_STRING      		20
-#define	  FULL_VOLTAGE	  			82
-#define	  CHARGING_VOLTAGE	  		40
-#define   DEFAULT_CELL_TYPE         P42A
+#define   BATTERY_STRING			20
+#define	  FULL_VOLTAGE				82
+#define	  CHARGING_VOLTAGE			40
+#define   DEFAULT_CELL_TYPE			P42A
 #endif
 
-#define   SHUTDOWN_TIME		  		10
-#define   VESC_RPM            		1000
-#define   VESC_BOOT_TIME      		4000
-#define   VESC_SHUTDOWN_TIME      	1000
-#define   DUTY_CYCLE          		0.9
-#define   VOLTAGE_RECEIPT     		0.02
+#define   SHUTDOWN_TIME				10
+#define   VESC_RPM					1000
+#define   VESC_BOOT_TIME			4000
+#define   VESC_SHUTDOWN_TIME		1000
+#define   DUTY_CYCLE				0.9
+#define   VOLTAGE_RECEIPT			0.02
 #define	  CHARGE_COMMAND_TIME		1000 		// frequency of notifying the float package of current charge state
 /*******************************************************************************/
-#define   VESC_RPM_WIDTH      		-200
-#define   WS2812_1_BRIGHTNESS 		20
-#define   WS2812_2_BRIGHTNESS 		10
-#define   WS2812_3_BRIGHTNESS 		5
+#define   VESC_RPM_WIDTH			-200
+#define   WS2812_1_BRIGHTNESS		20
+#define   WS2812_2_BRIGHTNESS		10
+#define   WS2812_3_BRIGHTNESS		5
 #define   CHARGE_CURRENT			0.12
-#define   DETECTION_SWITCH_TIME     500
+#define   DETECTION_SWITCH_TIME		500
 #define   CHARGER_DETECTION_DELAY	1000
-#define   NUM_LEDS 					10
+#define   NUM_LEDS					10
 #define   DEFAULT_IDLE_MODE			0
 
 void LED_Task(void);
@@ -65,6 +65,3 @@ void VESC_State_Task(void);
 void Flashlight_Detection(void);
 
 #endif
-
-
-

--- a/LCM/Code/App/task.h
+++ b/LCM/Code/App/task.h
@@ -10,8 +10,9 @@
 typedef enum
 {
 	P42A,
-	DG40
-} CELL_TYPE;
+	DG40,
+    VTC6
+} CELL_TYPES;
 
 //#define PINTV
 #define XRV
@@ -20,16 +21,17 @@ typedef enum
 
 #define USE_BUZZER
 
-#define   CELL_TYPE                 P42A        // Cell configuration to use for voltage display (P42A, DG40)
-
 #if defined(GTV)
 #define   BATTERY_STRING      		18
+#define   DEFAULT_CELL_TYPE         P42A
 #elif defined(PINTV) || defined(XRV)
 #define   BATTERY_STRING      		15
+#define   DEFAULT_CELL_TYPE         VTC6
 #elif defined(ADV)
 #define   BATTERY_STRING      		20
 #define	  FULL_VOLTAGE	  			82
 #define	  CHARGING_VOLTAGE	  		40
+#define   DEFAULT_CELL_TYPE         P42A
 #endif
 
 #define   SHUTDOWN_TIME		  		10


### PR DESCRIPTION
As there are functional differences between the ADV, GTV, PintV, and XRV, this PR aims to allow for building the LCM firmware for each of those four configurations. The changes include:

1. Adding a `config.h` file where differences between the platforms can he defined
2. Setting the number of battery cells for PintV to 15
3. Disabling the status light bar for XRV as it's not used
4. Adding the ability to re-enable the buzzer with a few different options
5. Adding new targets in uVision to allow for easily switching between the different platforms and to facilitate batch building