### PR TITLE
Add defensive checks to UART processing and remove system reset in factory reset

### DIFF
--- a/LCM/Code/App/flag_bit.c
+++ b/LCM/Code/App/flag_bit.c
@@ -48,7 +48,7 @@ uint8_t Power_Display_Flag = 0;
 	Buzzer_Flag = 1；蜂鸣器不响
 	Buzzer_Flag = 2；蜂鸣器响
 */
-//uint8_t Buzzer_Flag = 0;
+uint8_t Buzzer_Flag = 0;
 
 /*
 	Usart_Flag = Vesc_Data_Ready
@@ -58,7 +58,8 @@ uint8_t Vesc_Data_Ready = 0;
 /*
 	蜂鸣器响的时间
 */
-//uint16_t Buzzer_Time = 0;
+uint16_t Buzzer_Time = 0;
+
 /*
 	充电计时
 */
@@ -114,7 +115,8 @@ uint8_t WS2812_Measure = 0;
 /*
 	 Buzzer frequency in BPM, beats per minute, ranging from 60 to 180, corresponding to a duty cycle of 70 to 100)
 */
-//uint8_t Buzzer_Frequency = 0;
+uint8_t Buzzer_Frequency = 0;
+
 /*
 	 When the button is double-clicked without pressing it, the headlight stays on for 3 seconds.
 */

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -17,11 +17,11 @@ static void lcmConfigReset(void)
 	lcmConfig.headlightIdleBrightness = 0;
 	lcmConfig.statusbarBrightness = 5;
 	lcmConfig.boardOff = 0;
+	lcmConfig.dutyBeep = 90;
 	/*
 	lcmConfig.statusBarIdleMode = DEFAULT_IDLE_MODE;
 	lcmConfig.chargeCutoffVoltage = 0;
 	lcmConfig.bootAnimation = BOOT_DEFAULT;
-	lcmConfig.dutyBeep = 90;
 	lcmConfig.autoShutdownTime = SHUTDOWN_TIME;
 	
 	EEPROM_ReadByte(BOOT_ANIMATION, &lcmConfig.bootAnimation);
@@ -92,14 +92,14 @@ void KEY1_Task(void)
 			if(Power_Flag == 2) // Boot completed
 			{
 				Idle_Time = 0;
-				/*if(Buzzer_Flag == 2)
+				if(Buzzer_Flag == 2)
 				{
 					Buzzer_Flag = 1;
 				}
 				else
 				{
 					Buzzer_Flag = 2;
-				}*/
+				}
 			}
 		break;
 	}
@@ -523,7 +523,7 @@ void Power_Task(void)
 					{
 						Power_Flag = 2; // Boot completed
 						Gear_Position = 1; // The default setting is 1st gear after power-on.
-						//Buzzer_Flag = 2;    // The default buzzer sounds when powering on
+						Buzzer_Flag = 2;    // The default buzzer sounds when powering on
 						power_step = 0;
 						WS2812_Display_Flag = 1;
 					}
@@ -660,7 +660,7 @@ void Charge_Task(void)
 		case 2:
 			CHARGE_ON;
 			Charge_Flag = 2;
-		    charge_step = 3;
+			charge_step = 3;
 			//Power_Flag = 1;	// Boot the VESC
 		break;
 		
@@ -807,10 +807,11 @@ void Headlights_Task(void)
 	}
 }
 
+#ifdef USE_BUZZER
+
 /**************************************************
  * @brie   :Buzzer_Task()
  **************************************************/
-#ifdef USE_BUZZER
 void Buzzer_Task(void)
 {
 	static uint8_t buzzer_step = 0;
@@ -818,9 +819,6 @@ void Buzzer_Task(void)
 	static uint8_t ring_frequency = 0;
 	static uint16_t sound_frequency = 0;
 
-	BUZZER_OFF;
-	return;
-	
 	if(Power_Flag != 2 || Buzzer_Flag == 1)
 	{
 		BUZZER_OFF;
@@ -1078,7 +1076,7 @@ void VESC_State_Task(void)
 	{
 		data.dutyCycleNow = -data.dutyCycleNow;
 	}
-#ifdef USE_BUZZER
+
 	// Duty Cycle beep
 	if ((lcmConfig.dutyBeep > 0) && (data.dutyCycleNow >= lcmConfig.dutyBeep))
 	{
@@ -1092,7 +1090,6 @@ void VESC_State_Task(void)
 	if (data.state > RUNNING_UPSIDEDOWN) {
 		Buzzer_Frequency = 0;
 	}
-#endif	
 	
 	if(data.rpm<0)
 	{
@@ -1102,7 +1099,7 @@ void VESC_State_Task(void)
 	if(data.state == RUNNING_FLYWHEEL) {
 		WS2812_Display_Flag = 2;
 		WS2812_Flag = 5;
-		//Buzzer_Frequency = 0;
+		Buzzer_Frequency = 0;
 	}
 	else if(data.rpm<VESC_RPM)
 	{

--- a/LCM/Code/App/task.h
+++ b/LCM/Code/App/task.h
@@ -13,19 +13,20 @@ typedef enum
 	DG40
 } CELL_TYPE;
 
+//#define PINTV
 #define XRV
 //#define GTV
 //#define ADV
 
+#define USE_BUZZER
+
 #define   CELL_TYPE                 P42A        // Cell configuration to use for voltage display (P42A, DG40)
 
-#ifdef GTV
+#if defined(GTV)
 #define   BATTERY_STRING      		18
-#endif
-#ifdef XRV
+#elif defined(PINTV) || defined(XRV)
 #define   BATTERY_STRING      		15
-#endif
-#ifdef ADV
+#elif defined(ADV)
 #define   BATTERY_STRING      		20
 #define	  FULL_VOLTAGE	  			82
 #define	  CHARGING_VOLTAGE	  		40

--- a/LCM/Code/App/vesc_uasrt.c
+++ b/LCM/Code/App/vesc_uasrt.c
@@ -12,6 +12,9 @@ uint8_t VESC_RX_Flag = 0;
 #ifdef XRV
 #define FIRMWARE_ID "XRV_2_1_2"
 #endif
+#ifdef PINTV
+#define FIRMWARE_ID "PintV_2_1_2"
+#endif
 #ifdef ADV
 #define FIRMWARE_ID "ADV_2_1_2"
 #endif

--- a/LCM/Code/App/vesc_uasrt.c
+++ b/LCM/Code/App/vesc_uasrt.c
@@ -87,7 +87,7 @@ void buffer_append_int16(uint8_t* buffer, int16_t number, uint8_t *index) {
 }
 
 void buffer_append_float16(uint8_t* buffer, float number, uint8_t scale, uint8_t *index) {
-    buffer_append_int16(buffer, (int16_t)(number * scale), index);
+	buffer_append_int16(buffer, (int16_t)(number * scale), index);
 }
 
 /**************************************************
@@ -204,7 +204,7 @@ uint32_t buffer_get_uint32(const uint8_t *buffer, int32_t *index) {
  * @retval :无
  **************************************************/
 float buffer_get_float16(const uint8_t *buffer, float scale, int32_t *index) {
-    return (float)buffer_get_int16(buffer, index) / scale;
+	return (float)buffer_get_int16(buffer, index) / scale;
 }
 /**************************************************
  * @brie   :buffer_get_float32()
@@ -213,7 +213,7 @@ float buffer_get_float16(const uint8_t *buffer, float scale, int32_t *index) {
  * @retval :无
  **************************************************/
 float buffer_get_float32(const uint8_t *buffer, float scale, int32_t *index) {
-    return (float)buffer_get_int32(buffer, index) / scale;
+	return (float)buffer_get_int32(buffer, index) / scale;
 }
 
 void Process_Command(uint8_t command, uint8_t data)
@@ -310,7 +310,7 @@ uint8_t Protocol_Parse(uint8_t * message)
 	crcpayload = crc16(&message[counter], len);
 	
 	if(crcpayload != (((uint16_t)message[counter+len])<<8|
-		             ((uint16_t)message[counter+len+1])))
+					 ((uint16_t)message[counter+len+1])))
 	{
 		return 1; //crc is wrong
 	}

--- a/LCM/Code/App/vesc_uasrt.h
+++ b/LCM/Code/App/vesc_uasrt.h
@@ -27,7 +27,7 @@ typedef struct {
 	uint8_t headlightIdleBrightness;
 	uint8_t statusbarBrightness;
 	//StatusBarIdleMode statusBarIdleMode;
-	//uint8_t dutyBeep;
+	uint8_t dutyBeep;
 	//float chargeCutoffVoltage;
 	//uint8_t autoShutdownTime;
 	bool boardOff;

--- a/LCM/Code/Drive/buzzer.c
+++ b/LCM/Code/Drive/buzzer.c
@@ -1,4 +1,5 @@
 #include "buzzer.h"
+#include "task.h"
 
 #ifdef USE_BUZZER
 
@@ -6,9 +7,9 @@ uint16_t Buzzer_Counter = 0;
 
 /**************************************************
  * @brie   :Buzzer_Init()
- * @note   :·äÃùÆ÷³õÊ¼»¯
- * @param  :ÎÞ
- * @retval :ÎÞ
+ * @note   :ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ê¼ï¿½ï¿½
+ * @param  :ï¿½ï¿½
+ * @retval :ï¿½ï¿½
  **************************************************/
 void Buzzer_Init(void)
 {
@@ -27,9 +28,9 @@ void Buzzer_Init(void)
 
 /**************************************************
  * @brie   :Buzzer_Scan()
- * @note   :·äÃùÆ÷É¨Ãè
- * @param  :ÎÞ
- * @retval :ÎÞ
+ * @note   :ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½É¨ï¿½ï¿½
+ * @param  :ï¿½ï¿½
+ * @retval :ï¿½ï¿½
  **************************************************/
 void Buzzer_Scan(void)
 {
@@ -56,9 +57,9 @@ void Buzzer_Scan(void)
 
 /**************************************************
  * @brie   :Buzzer_Ring()
- * @note   :·äÃùÆ÷Ïì
- * @param  :ring_time ÏìµÄÊ±¼ä
- * @retval :ÎÞ
+ * @note   :ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+ * @param  :ring_time ï¿½ï¿½ï¿½Ê±ï¿½ï¿½
+ * @retval :ï¿½ï¿½
  **************************************************/
 void Buzzer_Ring(uint16_t ring_time)
 {

--- a/LCM/Code/User/hk32f030m_it.c
+++ b/LCM/Code/User/hk32f030m_it.c
@@ -85,8 +85,8 @@ void HardFault_Handler(void)
   /* USER CODE END HardFault_IRQn 0 */
   while (1)
   {
-    /* USER CODE BEGIN W1_HardFault_IRQn 0 */
-    /* USER CODE END W1_HardFault_IRQn 0 */
+	/* USER CODE BEGIN W1_HardFault_IRQn 0 */
+	/* USER CODE END W1_HardFault_IRQn 0 */
   }
 }
 
@@ -160,23 +160,27 @@ void USART1_IRQHandler(void)
 {
 	static uint8_t count = 0;
 	
-	if((USART1->ISR & USART_ISR_RXNE) != 0)	//接收中断
+	if((USART1->ISR & USART_ISR_RXNE) != 0)	//Receiving interruption
 	{
 		USART_ClearFlag(USART1,USART_FLAG_RXNE);
-		if (count > 75) {
-			// all messages should be shorter than 75 bytes but you never know...
-			count = 75;
+		if (count < sizeof(VESC_RX_Buff)) {
+			// all messages should be shorter than 80 bytes but you never know...
+			VESC_RX_Buff[count++] = USART1->RDR; //Send the received data into the receiving buffer
 		}
-		VESC_RX_Buff[count++] = USART1->RDR; //将收到的数据发入接收缓冲区
+		else
+		{
+			// The message is too long, just do a dummy read
+			volatile uint8_t dummy = USART1->RDR;
+		}
 	}
-	if((USART1->ISR & USART_ISR_IDLE) != 0) //空闲中断
+	if((USART1->ISR & USART_ISR_IDLE) != 0) //Idle interruption
 	{
-		count = 0; //一帧数据接受完 下标清零
-		VESC_RX_Flag = 1; //接收标志位置1
+		count = 0; //After one frame of data is received, the count is cleared to zero
+		VESC_RX_Flag = 1; //Set flag position 1
 		USART_ClearFlag(USART1,USART_ISR_IDLE);
 		USART_ReceiveData(USART1);
 	}
-	if((USART1->ISR & USART_ISR_ORE) != 0)  //溢出中断
+	if((USART1->ISR & USART_ISR_ORE) != 0)  //Overflow
 	{
 		USART_ClearFlag(USART1,USART_FLAG_ORE);
 		USART_ReceiveData(USART1);

--- a/LCM/Code/User/hk32f030m_it.c
+++ b/LCM/Code/User/hk32f030m_it.c
@@ -18,6 +18,7 @@
 #include "buzzer.h"
 #include "test.h"
 #include "flag_bit.h"
+#include "task.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -136,7 +137,9 @@ void TIM6_IRQHandler(void)
 		TIM_ClearITPendingBit(TIM6, TIM_IT_Update);
 		
 		WS2812_Counter++;
-		//Buzzer_Time++;
+#ifdef USE_BUZZER
+		Buzzer_Time++;
+#endif
 		Charge_Time++;
 		Flashlight_Time++;
 		Usart_Time++;
@@ -152,7 +155,9 @@ void TIM6_IRQHandler(void)
 			Idle_Time++;
 		
 		KEY1_Scan();
-		//Buzzer_Scan();
+#ifdef USE_BUZZER
+		Buzzer_Scan();
+#endif
   }
 }
 


### PR DESCRIPTION
While debugging the UART processing code, I found that the length of the payload for the `COMM_CUSTOM_APP_DATA` message was 15, when it was expected to be 14 plus 2 bytes for each generic command. As such, `Process_Command` was being called for each received `COMM_CUSTOM_APP_DATA` with the first byte being the unknown 15th byte in the payload and the second byte being the first byte of the CRC. The random LCM shutdowns are likely due to this and that the `FACTORY_RESET` command handler would reset the system without performing any safety checks.

To address this issue, I've added some defensive checks to the UART processing and also removed the call to `NVIC_SystemReset()` in the `FACTORY_RESET` command handler since the MCU can just be reset by powering off the board, which seems like a much safer option.

I looked through the Refloat code to try and determine why the length of the `COMM_CUSTOM_APP_DATA` is 15, but did not see any obvious reason. I think this should be further investigated, but the changes in the PR should at least eliminate the random shut downs.