### PR TITLE
Correct ind, len and pdata to match the sent packet size

### DIFF
--- a/LCM/Code/App/vesc_uasrt.c
+++ b/LCM/Code/App/vesc_uasrt.c
@@ -315,8 +315,8 @@ uint8_t Protocol_Parse(uint8_t * message)
 		return 1; //crc is wrong
 	}
 	
-	id = message[counter++];
-	pdata = &message[counter];  
+	pdata = &message[counter];
+	id = pdata[ind++];
 	
 	switch(id)
 	{


### PR DESCRIPTION
The encoded length of the received message includes the message type id (`COMM_GET_VALUES`, `COMM_CUSTOM_APP_DATA`). When Refloat calls VESC_IF->send_app_data the `COMM_CUSTOM_APP_DATA` byte is prepended and the length is incremented [here](https://github.com/vedderb/bldc/blob/master/comm/commands.c#L1786-L1794).

The current implementation of `Protocol_Parse` counts the message length starting after the type id byte.

This PR adjusts the `Protocol_Parse` code so that:
* pdata points at the whole buffer of size len
* pdata[0] is the first byte of the message (the message type id)
* pdata[len - 1] is the last byte of the sent message
* ind is correctly constrained between 0 and len - 1