### PR TITLE
Show continuous battery percentage

### DIFF
--- a/LCM/Code/App/flag_bit.c
+++ b/LCM/Code/App/flag_bit.c
@@ -30,17 +30,7 @@ uint8_t WS2812_Display_Flag = 0;
 */
 uint8_t WS2812_Flag = 0;
 /*
-	Power_Display_Flag = 0; ¸ÕÉÏµç
-	Power_Display_Flag = 1£» 4.08V~4.2V 	10¸ö°×µÆ
-	Power_Display_Flag = 2£» 4.05V~4.08V 9¸ö°×µÆ
-	Power_Display_Flag = 3£» 3.96V~4.05V 8¸ö°×µÆ
-	Power_Display_Flag = 4£» 3.87V~3.96V 7¸ö°×µÆ
-	Power_Display_Flag = 5£» 3.78V~3.87V 7¸ö°×µÆ
-	Power_Display_Flag = 6£» 3.70V~3.78V 5¸ö°×µÆ
-	Power_Display_Flag = 7£» 3.62V~3.70V 4¸ö°×µÆ
-	Power_Display_Flag = 8£» 3.50V~3.62V 3¸ö°×µÆ
-	Power_Display_Flag = 9£» 3.35V~3.50V 2¸öºìµÆ
-	Power_Display_Flag = 10; 2.80V~3.35V 1¸öºìµÆ
+	0 to 100% battery level
 */
 uint8_t Power_Display_Flag = 0;
 /*

--- a/LCM/Code/App/flag_bit.c
+++ b/LCM/Code/App/flag_bit.c
@@ -15,28 +15,33 @@ uint8_t Power_Flag = 0;
 */
 uint8_t Charge_Flag = 0;
 /*
-        Lightbar_Mode_Flag = 0; Just powered on.
-        Lightbar_Mode_Flag = 1; Display battery level.
-        Lightbar_Mode_Flag = 2; Do not display battery level.
+	Lightbar_Mode_Flag = 0; Just powered on.
+	Lightbar_Mode_Flag = 1; Display battery level.
+	Lightbar_Mode_Flag = 2; Do not display battery level.
 */
 uint8_t WS2812_Display_Flag = 0;
 /*
-        Footpad_Activation_Flag = 0; Just powered on.
-        Footpad_Activation_Flag = 1; Left 5 LEDs blue, Right 5 LEDs off (adc1 > 2.5V, adc2 < 2.5V).
-        Footpad_Activation_Flag = 2; Left 5 LEDs off, Right 5 LEDs blue (adc1 < 2.5V, adc2 > 2.5V).
-        Footpad_Activation_Flag = 3; All 10 LEDs blue (adc1 > 2.5V, adc2 > 2.5V).
-        Footpad_Activation_Flag = 4; All 10 LEDs off.
-        Footpad_Activation_Flag = 5; Flywheel mode, pattern
+	Footpad_Activation_Flag = 0; Just powered on.
+	Footpad_Activation_Flag = 1; Left 5 LEDs blue, Right 5 LEDs off (adc1 > 2.5V, adc2 < 2.5V).
+	Footpad_Activation_Flag = 2; Left 5 LEDs off, Right 5 LEDs blue (adc1 < 2.5V, adc2 > 2.5V).
+	Footpad_Activation_Flag = 3; All 10 LEDs blue (adc1 > 2.5V, adc2 > 2.5V).
+	Footpad_Activation_Flag = 4; All 10 LEDs off.
+	Footpad_Activation_Flag = 5; Flywheel mode, pattern
 */
 uint8_t WS2812_Flag = 0;
+/*
+	WS2812_Inhibit = 0; Allow refresh of WS2812
+	WS2812_Inhibit = 1; Inhibit refresh of WS2812
+*/
+uint8_t WS2812_Inhibit = 0;
 /*
 	0 to 100% battery level
 */
 uint8_t Power_Display_Flag = 0;
 /*
-	Buzzer_Flag = 0; 刚上电
-	Buzzer_Flag = 1；蜂鸣器不响
-	Buzzer_Flag = 2；蜂鸣器响
+	Buzzer_Flag = 0; Just powered up
+	Buzzer_Flag = 1锛汿he buzzer doesn't sound
+	Buzzer_Flag = 2锛汢uzzer rings
 */
 uint8_t Buzzer_Flag = 0;
 
@@ -46,24 +51,24 @@ uint8_t Buzzer_Flag = 0;
 uint8_t Vesc_Data_Ready = 0;
 
 /*
-	蜂鸣器响的时间
+	Time of buzzer ringing
 */
 uint16_t Buzzer_Time = 0;
 
 /*
-	充电计时
+	Charging timing
 */
 uint16_t Charge_Time = 0;
 /*
-	照明灯
+	Lighting
 */
 uint16_t Flashlight_Time = 0;
 /*
-	开机时间
+	Start time
 */
 uint16_t Power_Time = 0;
 /*
-	串口通信
+	Serial port communication
 */
 uint16_t Usart_Time = 0;
 /*
@@ -99,7 +104,7 @@ float Charge_Voltage = 0;
 */
 uint8_t Gear_Position = 0;
 /*
-	WS2812量度
+	WS2812 Measurement
 */
 uint8_t WS2812_Measure = 0;
 /*

--- a/LCM/Code/App/flag_bit.h
+++ b/LCM/Code/App/flag_bit.h
@@ -6,6 +6,7 @@
 extern uint8_t Power_Flag;
 extern uint8_t Charge_Flag;
 extern uint8_t WS2812_Display_Flag;
+extern uint8_t WS2812_Inhibit;
 extern uint8_t WS2812_Flag;
 extern uint8_t Power_Display_Flag;
 extern uint8_t Buzzer_Flag;

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -560,23 +560,27 @@ void Power_Task(void)
 void CheckPowerLevel(float battery_voltage)
 {
 	#ifdef P42A
-	float battVoltages[11] = {4.054, 4.01, 3.908, 3.827, 3.74, 3.651, 3.571, 3.485, 3.38, 3.0, 2.7}; //P42A
+	float battVoltages[11] = {4.2, 4.065, 3.938, 3.854, 3.776, 3.695, 3.618, 3.543, 3.46, 3.342, 3.0}; //P42A
 	#endif
 
 	#ifdef DG40
-	float battVoltages[11] = {4.07, 4.025, 3.91, 3.834, 3.746, 3.607, 3.49, 3.351, 3.168, 2.81, 2.7}; //DG40
+	float battVoltages[11] = {4.2, 4.047, 3.944, 3.867, 3.799, 3.717, 3.6, 3.498, 3.381, 3.237, 3.0}; //DG40
 	#endif
 
 	#ifdef VTC6
-	float battVoltages[11] = { 4.1, 4.00, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.1, 3.0}; // Sony VTC6
+	float battVoltages[11] = {4.2, 4.064, 4.015, 3.895, 3.821, 3.745, 3.655, 3.559, 3.459, 3.292, 3.0}; // Sony VTC6
 	#endif
 
-	// Default: Zero percent
-	Power_Display_Flag = 0;
-	for (int i = 1; i <= 10; i++) {
-		if (battery_voltage >= battVoltages[i]) {
-			Power_Display_Flag = 10.0f * ((10 - i) + (battery_voltage - battVoltages[i]) / (battVoltages[i - 1] - battVoltages[i]));
-			break;
+	if (battery_voltage >= battVoltages[0]) {
+		Power_Display_Flag = 100;
+	} else if (battery_voltage <= battVoltages[10]) {
+		Power_Display_Flag = 0;
+	} else {
+		for (int i = 1; i <= 10; i++) {
+			if (battery_voltage >= battVoltages[i]) {
+				Power_Display_Flag = 10.0f * ((10 - i) + (battery_voltage - battVoltages[i]) / (battVoltages[i - 1] - battVoltages[i]));
+				break;
+			}
 		}
 	}
 }
@@ -620,7 +624,7 @@ void Charge_Task(void)
 		{
 			if((Charge_Flag == 2) && (Charge_Time > 150))
 			{
-				CheckPowerLevel((Charge_Voltage+1)/BATTERY_STRING);
+				CheckPowerLevel(Charge_Voltage/BATTERY_STRING);
 			}
 			if((Charge_Flag == 3) && (Shutdown_Cnt > 10))
 			{
@@ -1087,7 +1091,7 @@ void VESC_State_Task(void)
 
 	// Not charging? Get voltage from VESC
 	if (data.inpVoltage > 0) {
-		CheckPowerLevel((data.inpVoltage+1)/BATTERY_STRING);
+		CheckPowerLevel(data.inpVoltage/BATTERY_STRING);
 	}
 
 	if(data.dutyCycleNow < 0)

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -1013,7 +1013,7 @@ void Usart_Task(void)
 			}
 			else if(Usart_Time >= USART_TIMEOUT_MS)
 			{
-				usart_step = 0;
+				usart_step = 2;
 
 				// The data was not received in time, so allow the WS2812 to refresh
 				WS2812_Inhibit = 0;

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -129,8 +129,12 @@ static void WS2812_Power_Display(uint8_t brightness)
 		g = brightness;
 	if (Power_Display_Flag > 40)
 		b = brightness;
-	
-	WS2812_Set_AllColours(1, numleds, r, g, b);
+
+	if (numleds > 0) {
+		WS2812_Set_AllColours(1, numleds, r, g, b);
+	} else {
+		WS2812_Set_AllColours(1, 10, 0, 0, 0);
+	}
 
 	if (remainder > 0) {
 		float scale = remainder / 10.0f;

--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -137,11 +137,11 @@ static void WS2812_Power_Display(uint8_t brightness)
 	}
 
 	if (remainder > 0) {
-		float scale = remainder / 10.0f;
-		WS2812_Set_Colour(numleds, r * scale, g * scale, b * scale);
+		r = ((uint16_t)r * remainder) / 10;
+		g = g ? r : 0;
+		b = b ? r : 0;
+		WS2812_Set_Colour(numleds, r, g, b);
 	}
-
-	WS2812_Refresh();
 }
 
 /**************************************************
@@ -543,25 +543,27 @@ void Power_Task(void)
 void CheckPowerLevel(float battery_voltage)
 {
 	#ifdef P42A
-	float battVoltages[11] = {4.2, 4.065, 3.938, 3.854, 3.776, 3.695, 3.618, 3.543, 3.46, 3.342, 3.0}; //P42A
+	uint16_t battVoltages_mv[11] = {4200, 4065, 3938, 3854, 3776, 3695, 3618, 3543, 3460, 3342, 3000}; //P42A
 	#endif
 
 	#ifdef DG40
-	float battVoltages[11] = {4.2, 4.047, 3.944, 3.867, 3.799, 3.717, 3.6, 3.498, 3.381, 3.237, 3.0}; //DG40
+	uint16_t battVoltages_mv[11] = {4200, 4047, 3944, 3867, 3799, 3717, 3600, 3498, 3381, 3237, 3000}; //DG40
 	#endif
 
 	#ifdef VTC6
-	float battVoltages[11] = {4.2, 4.064, 4.015, 3.895, 3.821, 3.745, 3.655, 3.559, 3.459, 3.292, 3.0}; // Sony VTC6
+	uint16_t battVoltages_mv[11] = {4200, 4064, 4015, 3895, 3821, 3745, 3655, 3559, 3459, 3292, 3000}; // Sony VTC6
 	#endif
+	
+    uint16_t battery_voltage_mv = battery_voltage * 1000;
 
-	if (battery_voltage >= battVoltages[0]) {
+	if (battery_voltage_mv >= battVoltages_mv[0]) {
 		Power_Display_Flag = 100;
-	} else if (battery_voltage <= battVoltages[10]) {
+	} else if (battery_voltage_mv <= battVoltages_mv[10]) {
 		Power_Display_Flag = 0;
 	} else {
 		for (int i = 1; i <= 10; i++) {
-			if (battery_voltage >= battVoltages[i]) {
-				Power_Display_Flag = 10.0f * ((10 - i) + (battery_voltage - battVoltages[i]) / (battVoltages[i - 1] - battVoltages[i]));
+			if (battery_voltage_mv >= battVoltages_mv[i]) {
+				Power_Display_Flag = ((100 - i*10) + (10 * (battery_voltage_mv - battVoltages_mv[i])) / (battVoltages_mv[i - 1] - battVoltages_mv[i]));
 				break;
 			}
 		}

--- a/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml
+++ b/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml
@@ -3,7 +3,7 @@ solution:
   created-for: CMSIS-Toolbox@2.4.0
   compiler: AC6@6.22.0
   variables:
-    - VERSION: 2_1_6
+    - VERSION: 2_1_8
 
   target-types:
     - type: ADV-P42A

--- a/LCM/build.bat
+++ b/LCM/build.bat
@@ -1,24 +1,24 @@
 @REM ADV-P42A
-cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-P42A --packs
-cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-P42A
-copy Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/ADV-P42A/Release/*.hex .
+cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-P42A --packs
+cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-P42A
+copy Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\ADV-P42A\Release\*.hex .
 
 @REM ADV-DG40
-cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-DG40 --packs
-cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-DG40
-copy Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/ADV-DG40/Release/*.hex .
+cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-DG40 --packs
+cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+ADV-DG40
+copy Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\ADV-DG40\Release\*.hex .
 
 @REM GTV
-cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+GTV --packs
-cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+GTV
-copy Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/GTV/Release/*.hex .
+cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+GTV --packs
+cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+GTV
+copy Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\GTV\Release\*.hex .
 
 @REM PINTV
-cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV --packs
-cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV
-cp Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/PINTV/Release/*.hex .
+cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV --packs
+cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV
+cp Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\PINTV\Release\*.hex .
 
 @REM XRV
-cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+XRV --packs
-cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+XRV
-copy Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/XRV/Release/*.hex .
+cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+XRV --packs
+cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+XRV
+copy Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\XRV\Release\*.hex .


### PR DESCRIPTION
The battery percentage display currently shows the battery level in discrete 10% increments. This PR modifies the display to show a more continuous battery percentage by dimming the high-order LED as the battery percentage decreases. For example, at 85% battery, the first 8 LED will be a full brightness and the 9th LED will be at 50% brightness (relative to the brightness setting for the status bar). This gives a more natural battery display that helps fill in those 10% gaps.