### PR TITLE
Match CMSIS and µVision output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ LCM/Project/MDK5/.clangd
 LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.cbuild-idx.yml
 LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.cbuild-set.yml
 LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New*.cbuild.yml
+LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New*.cbuild-run.yml

--- a/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.cproject.yml
+++ b/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.cproject.yml
@@ -1,6 +1,6 @@
 project:
   output:
-    base-name: $TargetType$
+    base-name: lcm_$OutputName$
     type: hex
   packs:
     - pack: HKMicroChip::HK32F030xMxx_DFP

--- a/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml
+++ b/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml
@@ -5,6 +5,8 @@ solution:
 
   target-types:
     - type: ADV-P42A
+      variables:
+        - OutputName: adv_p42a
       define:
         - ADV
         - P42A
@@ -14,6 +16,8 @@ solution:
         - FIRMWARE_ID_PREFIX: '"ADV"'
       device: HK_MicroChip::HK32F030MF4P6
     - type: ADV-DG40
+      variables:
+        - OutputName: adv_dg40
       define:
         - ADV
         - DG40
@@ -23,13 +27,17 @@ solution:
         - FIRMWARE_ID_PREFIX: '"ADV"'
       device: HK_MicroChip::HK32F030MF4P6
     - type: GTV
+      variables:
+        - OutputName: gtv
       define:
         - GTV
         - P42A
         - BATTERY_STRING: 18
         - FIRMWARE_ID_PREFIX: '"GTV"'
       device: HK_MicroChip::HK32F030MF4P6
-    - type: PINTV
+    - type: PintV
+      variables:
+        - OutputName: pintv
       define:
         - PINTV
         - VTC6
@@ -37,6 +45,8 @@ solution:
         - FIRMWARE_ID_PREFIX: '"PintV"'
       device: HK_MicroChip::HK32F030MF4P6
     - type: XRV
+      variables:
+        - OutputName: xrv
       define:
         - XRV
         - VTC6

--- a/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml
+++ b/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml
@@ -1,7 +1,7 @@
 solution:
   created-by: uv2csolution@1.5.0
-  created-for: CMSIS-Toolbox@2.4.0
-  compiler: AC6@6.22.0
+  created-for: CMSIS-Toolbox@2.8.0
+  compiler: AC6@6.23.0
 
   target-types:
     - type: ADV-P42A
@@ -58,7 +58,9 @@ solution:
       optimize: debug
       debug: on
     - type: Release
-      optimize: size
+      misc:
+        - C-CPP:
+          - -O1
       debug: off
   projects:
     - project: LCM_Light_Control_IO_WS2812_New.cproject.yml

--- a/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.uvprojx
+++ b/LCM/Project/MDK5/LCM_Light_Control_IO_WS2812_New.uvprojx
@@ -10,8 +10,8 @@
       <TargetName>lcm_pintv</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::ARMCLANG</pArmCC>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6230000::V6.23::ARMCLANG</pArmCC>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -578,8 +578,8 @@
       <TargetName>lcm_xrv</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::ARMCLANG</pArmCC>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6230000::V6.23::ARMCLANG</pArmCC>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -1146,8 +1146,8 @@
       <TargetName>lcm_gtv</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::ARMCLANG</pArmCC>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6230000::V6.23::ARMCLANG</pArmCC>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -1714,8 +1714,8 @@
       <TargetName>lcm_adv_p42a</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::ARMCLANG</pArmCC>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6230000::V6.23::ARMCLANG</pArmCC>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -2282,8 +2282,8 @@
       <TargetName>lcm_adv_dg40</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::ARMCLANG</pArmCC>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6230000::V6.23::ARMCLANG</pArmCC>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>

--- a/LCM/build.bat
+++ b/LCM/build.bat
@@ -14,9 +14,9 @@ cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set 
 copy Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\GTV\Release\*.hex .
 
 @REM PINTV
-cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV --packs
-cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV
-cp Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\PINTV\Release\*.hex .
+cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PintV --packs
+cbuild Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PintV
+cp Project\MDK5\out\LCM_Light_Control_IO_WS2812_New\PintV\Release\*.hex .
 
 @REM XRV
 cbuild setup Project\MDK5\LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+XRV --packs

--- a/LCM/build.sh
+++ b/LCM/build.sh
@@ -14,9 +14,9 @@ cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set 
 cp Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/GTV/Release/*.hex ./
 
 # PINTV
-cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV --packs
-cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PINTV
-cp Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/PINTV/Release/*.hex ./
+cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PintV --packs
+cbuild Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+PintV
+cp Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/PintV/Release/*.hex ./
 
 # XRV
 cbuild setup Project/MDK5/LCM_Light_Control_IO_WS2812_New.csolution.yml --context-set --context LCM_Light_Control_IO_WS2812_New.Release+XRV --packs

--- a/README.md
+++ b/README.md
@@ -1,29 +1,48 @@
 # Floatwheel LCM Firmware
 
-#### Linux Prerequisites
-
-1. Install `libncurses5` and 'curl' via your package manager of choice
-
 ## Setting up the project
 
+### Using VSCode
+
 1. Install [Visual Studio Code](https://code.visualstudio.com)
-1. Type 'code' to run it
-1. Open `floatwheel` folder in Visual Studio Code
-1. Install [Keil Studio Pack](https://marketplace.visualstudio.com/items?itemName=Arm.keil-studio-pack) extension [^1]
-1. Wait for Arm Tools to finish downloading / installing [^2][^3]
-1. Activate Keil MDK Community license when prompted
-1. Open a terminal in Visual Studio Code
-1. Input `cpackget add LCM/HKMicroChip.HK32F030xMxx_DFP.1.0.17.pack` and press Enter/Return [^4]
-1. Use CMSIS tab to select target device and build / debug[^5]
+2. Type 'code' to run it
+3. Open `floatwheel` folder in Visual Studio Code
+4. Install [Keil Studio Pack](https://marketplace.visualstudio.com/items?itemName=Arm.keil-studio-pack) extension [^1]
+5. Wait for Arm Tools to finish downloading / installing [^2][^3]
+6. Activate Keil MDK Community license when prompted
+7. Open a terminal in Visual Studio Code
+8. Input `cpackget add LCM/HKMicroChip.HK32F030xMxx_DFP.1.0.17.pack` and press Enter/Return [^4]
+9. Use CMSIS tab to select target device and build / debug [^5]
 
 ![Example build environment](./Docs/lcm-arm-cmsis-vscode.jpg "Example build environment")
 
-Build scripts are also included: `LCM/build.sh` (Linux / Mac OS) `LCM/build.bat` (Windows) 
+### Using vcpkg
 
-They build firmware for all 4 configurations, then copy the created `<device>.hex` files into the `LCM` directory. The intention is to use them when releasing new versions until a future solution is reached.
+1. Install [vcpkg](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/installation/)
+2. Initialize it in the current shell
+3. Change to the `floatwheel` folder and install / activate the environment with `vcpkg-shell activate`
+4. Activate Keil MDK Community license with `armlm activate -product KEMDK-COM0 -server https://mdk-preview.keil.arm.com`
+5. Install the microprocessor pack with `cpackget add LCM/HKMicroChip.HK32F030xMxx_DFP.1.0.17.pack`
+
+Steps 2 and 3 need to be performed in every new shell.
+
+### Using Keil µVision
+
+1. Install [Keil µVision 5](https://www.keil.arm.com/mdk-community/) from https://armkeil.blob.core.windows.net/eval/MDK542a.exe
+2. Install the microprocessor pack at `LCM\HKMicroChip.HK32F030xMxx_DFP.1.0.17.pack` by double clicking it
+3. Open µVision, click Project -> Open Project and choose `LCM\Project\MDK5\LCM_Light_Control_IO_WS2812_New.uvprojx`
+4. Build the firmware with Project -> Batch Build [^6]
+
+## Batch building
+
+Build scripts are also included [^7]: `LCM/build.sh` (Linux / Mac OS) `LCM/build.bat` (Windows)
+
+They build firmware for all 5 configurations, then copy the created `lcm_<device>.hex` files into the `LCM` directory. The intention is to use them when releasing new versions until a future solution is reached.
 
 [^1]: This should be suggested automatically
 [^2]: Located on the bottom bar, will show either Arm Tools: x or Installing...(xx%)
 [^3]: This process takes quite some time. Check `Output -> Arm Tools` for details
-[^4]: Try adding `~/.vcpkg/artifacts/2139c4c6/tools.open.cmsis.pack.cmsis.toolbox/2.6.1/bin/` to $PATH if you're having issues running cpackget
+[^4]: Try adding `~/.vcpkg/artifacts/2139c4c6/tools.open.cmsis.pack.cmsis.toolbox/2.8.0/bin/` to $PATH if you're having issues running cpackget
 [^5]: .hex file located at `LCM/Project/MDK5/out/LCM_Light_Control_IO_WS2812_New/<device>` in Debug / Release folder
+[^6]: .hex files located at `LCM\Project\MDK5\Objects\<target>.hex`
+[^7]: Only for VSCode and vcpkg installs

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,10 +7,9 @@
     }
   ],
   "requires": {
-    "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.6.1",
-    "arm:compilers/arm/armclang": "6.22.0",
+    "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.8.0",
+    "arm:compilers/arm/armclang": "6.23.0",
     "arm:tools/kitware/cmake": "3.28.4",
-    "arm:compilers/arm/llvm-embedded": "19.1.1",
     "arm:tools/ninja-build/ninja": "1.12.0"
   }
 }


### PR DESCRIPTION
This PR adjusts the CMSIS and µVision projects to generate the same binary output:
* Changes compiler version to Armclang 6.23 (latest version in µVision 5.42a)
* Forces optimization level to -01 to match µVision
* Adjusts CMSIS output file names to match the changes from #25 

Also updates the Readme with instructions for µVision and CMSIS toolbox on *nix systems.

Next PR will add automatic builds in CI using the CMSIS tools.
